### PR TITLE
Add information to debug web site

### DIFF
--- a/dotnet/Language/FrontendService/FrontendService/Controllers/LanguageController.cs
+++ b/dotnet/Language/FrontendService/FrontendService/Controllers/LanguageController.cs
@@ -37,7 +37,7 @@ namespace FrontendService.Controllers
         /// <returns>Always returns "healthy" if the app is able.</returns>
         public string Get()
         {
-            return "healthy";
+            return "healthy, cognitive service container endpoint = " + ServiceEndpoint;
         }
 
         /// <summary>
@@ -48,9 +48,14 @@ namespace FrontendService.Controllers
         [HttpGet("{text}")]
         public async Task<string> DetectLanguage([FromRoute] string text)
         {
-            var inputs = new List<Input>() { new Input("id", text) };
-            var result = await _taClient.DetectLanguageAsync(new BatchInput(inputs));
-            return result.Documents[0].DetectedLanguages[0].Name;
+            try{
+                var inputs = new List<Input>() { new Input("id", text) };
+                var result = await _taClient.DetectLanguageAsync(new BatchInput(inputs));
+                return result.Documents[0].DetectedLanguages[0].Name;
+            } catch(Exception ex){
+                // returns error is cognitive service container can't be reached
+                return ex.Message;
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
Applies to TA Language Frontend website in .Net.

Add debug information to determine if TA container is available. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X ] Other... Please describe: respond with exception if TA container isn't available
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Delete pod service and deployment for language so that the exposed container https://language:5000 is not available. 

## What to Check
When the language-frontend container is running, verify that it returns the error that the container isn't available. Also, make sure `kubectl get all` shows the container as staying up instead of crashing over and over.  

## Other Information
<!-- Add any other helpful information that may be needed here. -->